### PR TITLE
Remove discord bot token from source control, add instructions in readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,4 +102,7 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# project
 credentials.json
+discordbot_token.txt

--- a/README.md
+++ b/README.md
@@ -8,15 +8,24 @@ This bot allows GenerateTask users and accounts to interact with the leaderboard
 
 Make sure credentials.json is stored in the same directory as the bot.
 
-**Step 2:** Install Python dependencies
+**Step 2:** Create your own discord server and bot for testing
+
+Create your own discord server: https://support.discordapp.com/hc/en-us/articles/204849977-How-do-I-create-a-server-
+
+Discord bot and adding it to your server: https://github.com/reactiflux/discord-irc/wiki/Creating-a-discord-bot-&-getting-a-token
+
+Save the token in a new file called discordbot_token.txt and place it in the same directory as the bot
+
+**Step 3:** Install Python dependencies
 
 If you haven't installed Python yet, download it [here](https://www.python.org/).
 
 Install discordpy: `pip install discord-py`
 
 Run the pip command listed here: https://developers.google.com/sheets/api/quickstart/python#step_2_install_the_google_client_library
+
 `pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib gspread oauth2client`
 
-**Step 3:** Run the bot
+**Step 4:** Run the bot
 
 `python init.py`

--- a/discordbot_token.txt
+++ b/discordbot_token.txt
@@ -1,1 +1,0 @@
-NTk0Mzc1Nzk5Njc5ODc3MTIw.XRkplQ.eGUyAVHNmOfz5YE-qNf-0UjdzGg


### PR DESCRIPTION
Everyone will have to do step 2 in readme to continue developing.

This will allow everyone to work on their own server/bot so we can develop concurrently.