### PR TITLE
Automatic update

### DIFF
--- a/gsheet.py
+++ b/gsheet.py
@@ -20,40 +20,49 @@ class gsheet(object):
         gsclient = gspread.authorize(creds)
         sheet = gsclient.open_by_key(self.LEADERBOARDS_ID)
         worksheet = sheet.worksheet("RawData")
-    
+
     def updateTaskAccount(self, taskAccount):
         try:
             scope = ['https://spreadsheets.google.com/feeds',
             'https://www.googleapis.com/auth/drive']
             creds = ServiceAccountCredentials.from_json_keyfile_name('client_secret.json', scope)
-            gsclient = gspread.authorize(creds)
-            sheet = gsclient.open_by_url(taskAccount.spreadsheetUrl)
 
-            ranges = [
-                ['Easy', 3],
-                ['Medium', 3],
-                ['Hard', 3],
-                ['Elite', 3],
-                ['Master', 3],
-                ['God', 3]
+            service = build('sheets', 'v4', credentials=creds)
+            sheet = service.spreadsheets()
+
+            range_names = [
+                'Easy!C2:C',
+                'Medium!C2:C',
+                'Hard!C2:C',
+                'Elite!C2:C',
+                'Master!C2:C',
+                'God!C2:C',
+                'DASHBOARD!B15'
             ]
 
+            result = sheet.values().batchGet(
+                spreadsheetId = self.getIdFromUrl(taskAccount.spreadsheetUrl),
+                ranges=range_names).execute()
+
             i = 0
-            difficultyCompletions = [0,0,0,0,0,0]
-            for range in ranges:
-                difficultyCompletions[i] = sheet.worksheet(range[0]).col_values(range[1])
+            difficultyCompletions = [[],[],[],[],[],[],[]]
+            for range in result.get('valueRanges', []):
+                difficultyCompletions[i] = range.get('values')
                 i+=1
 
             i = 0
             difficultyTotals = [0,0,0,0,0,0]
-            for difficultyCompletion in difficultyCompletions:
+            for difficultyCompletion in difficultyCompletions[:len(difficultyCompletions) - 2]:
                 count = 0
                 for taskCompletion in difficultyCompletion:
-                    if(taskCompletion == 'x'):
+                    if(len(taskCompletion) != 0):
                         count+=1
                 difficultyTotals[i] = count
                 i+=1
-            currentTask = sheet.worksheet('DASHBOARD').cell(15,2).value
+            if(len(difficultyCompletions[0][6]) != 0):
+                currentTask = difficultyCompletions[len(difficultyCompletions)-1][0][0]
+            else:
+                currentTask = 'None'
 
             taskAccount.easyProgress = int(difficultyTotals[0])
             taskAccount.mediumProgress = int(difficultyTotals[1])
@@ -62,12 +71,9 @@ class gsheet(object):
             taskAccount.masterProgress = int(difficultyTotals[4])
             taskAccount.godProgress = int(difficultyTotals[5])
             taskAccount.currentTask = currentTask
-            taskAccount.lastUpdated = time()
 
             self.updateLeaderboards(taskAccount)
-        except gspread.exceptions.APIError: raise 
-
-        
+        except Exception: raise
 
     def updateLeaderboards(self, taskAccount):
         scope = ['https://spreadsheets.google.com/feeds',

--- a/taskAccount.py
+++ b/taskAccount.py
@@ -10,9 +10,12 @@ class taskAccount(object):
     eliteProgress = 0
     masterProgress = 0
     godProgress = 0
-    lastUpdated = 0
     currentTask = 'Unknown'
     isOfficial = False
+
+    # In the taskAccountList, this parameter has to be modified through the updateLastUpdated method because
+    # it is used as the sorting key. Any other way of changing it might make it unretrievable from the list
+    lastUpdated = 0
 
     def __init__(self, spreadsheetUrl, nickname, isOfficial):
         self.spreadsheetUrl = spreadsheetUrl
@@ -28,8 +31,8 @@ class taskAccount(object):
     def formatTimeSinceUpdate(self):
         timeSinceLastUpdate = time() - self.lastUpdated
         seconds = round(timeSinceLastUpdate % 60, 2)
-        minutes = floor(timeSinceLastUpdate/60)
-        hours = floor(timeSinceLastUpdate/(60*60))
+        minutes = floor(timeSinceLastUpdate/60) % 60
+        hours = floor(timeSinceLastUpdate/(60*60)) % 24
         days = floor(timeSinceLastUpdate/(60*60*24))
 
         return f'{days} days {hours} hours {minutes} minutes {seconds} seconds'

--- a/taskAccountList.py
+++ b/taskAccountList.py
@@ -1,0 +1,21 @@
+# The point of this class is to provide a list that has a sort() method and a rotate() method
+# without having to create and reassign a new list
+
+class taskAccountList():
+
+    taskAccounts = []
+
+    def __init__(self, taskAccounts = []):
+        self.taskAccounts = taskAccounts
+
+    def sort(self, reverse):
+        self.taskAccounts.sort(key = self.sortFunc, reverse = reverse)
+
+    def sortFunc(self, taskAccount):
+        return taskAccount.lastUpdated
+
+    def add(self, taskAccount):
+        self.taskAccounts.append(taskAccount)
+
+    def rotate(self, n):
+        self.taskAccounts = self.taskAccounts[n:] + self.taskAccounts[:n]

--- a/taskAccountList.py
+++ b/taskAccountList.py
@@ -1,21 +1,26 @@
-# The point of this class is to provide a list that has a sort() method and a rotate() method
-# without having to create and reassign a new list
+from sortedcontainers import SortedKeyList
+
+def sortFunc(taskAccount):
+    return taskAccount.lastUpdated
 
 class taskAccountList():
 
-    taskAccounts = []
-
-    def __init__(self, taskAccounts = []):
-        self.taskAccounts = taskAccounts
-
-    def sort(self, reverse):
-        self.taskAccounts.sort(key = self.sortFunc, reverse = reverse)
-
-    def sortFunc(self, taskAccount):
-        return taskAccount.lastUpdated
+    taskAccounts = SortedKeyList(key = sortFunc)
 
     def add(self, taskAccount):
-        self.taskAccounts.append(taskAccount)
+        self.taskAccounts.add(taskAccount)
 
-    def rotate(self, n):
-        self.taskAccounts = self.taskAccounts[n:] + self.taskAccounts[:n]
+    def getOldestUpdatedAccounts(self, n):
+        numberOfAccounts = len(list(self.taskAccounts.islice()))
+        if(numberOfAccounts == 0):
+            return list()
+        elif(numberOfAccounts > n):
+            return list(self.taskAccounts.islice(0,n))
+        else:
+            return list(self.taskAccounts.islice(0,numberOfAccounts))
+
+    def updateLastUpdated(self, taskAccount, lastUpdated):
+        # We have to remove the account and put it back into the list because lastUpdated is also the sorting key
+        self.taskAccounts.remove(taskAccount)
+        taskAccount.lastUpdated = lastUpdated
+        self.taskAccounts.add(taskAccount)


### PR DESCRIPTION
There is a lot going on in this one, going to try to be as clear as possible:

- Use Google Sheets API instead of gspread to read spreadsheets. The implementation in gspread ended up splitting a read into multiple requests which was both slow and caused issues with the rate limit imposed by Google (100 requests per 100 seconds).

- Add method to get a file's last updated timestamp. This doesn't exist on the Google Sheets API so I had to use the Google Drive API instead.

- Add a looping task that updates task accounts. This task compares the last time the bot looked at their spreadsheet and the last update on the sheet itself and decides to update the account if the spreadsheet has been updated more recently than the bot.

- Created a wrapper class for a sorted list. This allows efficient picking of the accounts that have been updated the longest ago (and thus need updated the most). We can't try to update all of the accounts at once because of the rate limit of Google.